### PR TITLE
Link to the multi page documentation for old versions

### DIFF
--- a/js/versions.js
+++ b/js/versions.js
@@ -16,7 +16,8 @@ $(document).ready(function() {
 
   var updateDocumentationVersion = function(version) {
     var prefix = "http://www.querydsl.com/static/querydsl/" + version;
-    $("#docs .docs").attr("href", prefix + "/reference/html_single/");
+    var isOldVersion = parseFloat(version) < 3.2;
+    $("#docs .docs").attr("href", prefix + isOldVersion ? "/reference/html/" : "/reference/html_single/");
     //$("#docs .korean").attr("href", prefix + "/reference/ko-KR/html_single");
     $("#docs .javadocs").attr("href", prefix + "/apidocs/");
     $("#docs .downloads").attr("href", prefix);


### PR DESCRIPTION
For versions earlier than 3.2 (specifically 3.1.1) the documentation resides in the multi page html document structure instead of the single html page.